### PR TITLE
Added styles to message headers and messages with subtypes.

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -78,10 +78,14 @@ func (t *MarkdownTranslator) ToMessageList(chunk []MessageResolved) []string {
 		} else {
 			// `subtype=file_comment` does not have `user` or `bot_id`
 		}
-		header += ": "
-		md = append(md, "* "+header)
+		header += ":"
+		md = append(md, "* *"+header+"* ")
 		for _, token := range m.MessageTokens {
 			switch token := token.(type) {
+			case MessageTokenEndSubtype:
+				md = append(md, "*")
+			case MessageTokenStartSubtype:
+				md = append(md, "*")
 			case MessageTokenNewLine:
 				md = append(md, "\n    ")
 			case MessageTokenText:

--- a/resolver.go
+++ b/resolver.go
@@ -22,6 +22,12 @@ type MessageTokenNewLine struct {
 type MessageTokenText struct {
 	Text string
 }
+type MessageTokenStartSubtype struct {
+	Text string
+}
+type MessageTokenEndSubtype struct {
+	Text string
+}
 type MessageTokenLink struct {
 	Href string
 	Text string
@@ -52,6 +58,12 @@ func (l *messageTokenListener) OnNewLine() {
 }
 func (l *messageTokenListener) OnText(text string) {
 	l.add(MessageTokenText{text})
+}
+func (l *messageTokenListener) OnEndSubtype(text string) {
+	l.add(MessageTokenEndSubtype{text})
+}
+func (l *messageTokenListener) OnStartSubtype(text string) {
+	l.add(MessageTokenStartSubtype{text})
 }
 func (l *messageTokenListener) OnLink(href, text string) {
 	text2 := text
@@ -119,7 +131,7 @@ func (r *Resolver) Resolve(m *Message) MessageResolved {
 	res.Ts = SlackTsToTime(m.Ts)
 
 	messageListner := newMessageTokenListener(r)
-	NewSlackMessageParser(messageListner).Parse(m.Text)
+	NewSlackMessageParser(messageListner).Parse(m.Text, m.Subtype)
 	res.MessageTokens = messageListner.Tokens
 
 	return *res

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -30,6 +30,7 @@ type Message struct {
 	User  string `json:"user"`
 	BotID string `json:"bot_id"`
 	Text  string `json:"text"`
+	Subtype  string `json:"subtype"`
 	Ts    string `json:"ts"`
 }
 


### PR DESCRIPTION
Added basic handling for message subtypes.

Came about as I wanted to have the message header in italics (wrapped with a "*") and to have non-user messages also in italics.

Summary of changes:
* Added subtype from the JSON to the message.
* Changed .Parse to take the subtype from the message
* Changed header to be wrapped by a "*"
* Added OnStartSubtype and OnEndSubtype events for listener to handle text wrapping.