### PR TITLE
Added nil check of user to avoid run-time error

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -72,7 +72,7 @@ func (l *messageTokenListener) OnChannel(channelID, alt string) {
 func (l *messageTokenListener) OnUser(userID, alt string) {
 	user := l.resolver.ResolveUser(userID)
 	text := alt
-	if "" == text {
+	if "" == text && nil != user {
 		text = user.Name
 	}
 	l.add(MessageTokenUser{user, text})


### PR DESCRIPTION
In some cases (e.g. in the message of slackbot), the `user` variable will be nil, causing a panic on the OnUser () function. In that case, the user `text` should not be changed.