### PR TITLE
Changed "Channel.Created"

### DIFF
--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Channel struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Created string `json:"created"`
+	ID      string      `json:"id"`
+	Name    string      `json:"name"`
+	Created json.Number `json:"created"`
 }
 
 type User struct {


### PR DESCRIPTION
An error occurs if the date is not enclosed in double quotes.(Not a bug)
There is no problem with the official slack export.
However, it is inconvenient for tools that obtain logs from the API. ([ex](https://github.com/PyYoshi/slack-dump))
The [json.Number](https://golang.org/pkg/encoding/json/#Number) type can accept strings and numbers.
Since the json.Number type inherits the string type, it does not adversely affect the current program.